### PR TITLE
estring: add formatNumber function

### DIFF
--- a/lib/base/estring.cpp
+++ b/lib/base/estring.cpp
@@ -3,6 +3,8 @@
 #include <cctype>
 #include <climits>
 #include <string>
+#include <sstream>
+#include <map>
 #include <lib/base/eerror.h>
 #include <lib/base/encoding.h>
 #include <lib/base/estring.h>
@@ -958,4 +960,36 @@ std::vector<std::string> split(std::string s, const std::string& separator)
 int strcasecmp(const std::string& s1, const std::string& s2)
 {
 	return ::strcasecmp(s1.c_str(), s2.c_str());
+}
+
+std::string formatNumber(size_t size, const std::string& suffix, bool binary)
+{
+	std::map<uint8_t, std::string> unit = {
+		{  24, "Y" },
+		{  21, "Z" },
+		{  18, "E" },
+		{  15, "P" },
+		{  12, "T" },
+		{   9, "G" },
+		{   6, "M" },
+		{   3, binary ? "K" : "k" },
+		{   0, ""  }
+	};
+
+	uint8_t k = 0;
+	size_t rem = 0;
+	uint16_t base = binary ? 1024 : 1000;
+
+	while (size >= base)
+	{
+		rem = size % base;
+		k += 3;
+		size /= base;
+	}
+
+	float num = size + (rem*1.0f/base);
+
+	std::stringstream ss;
+	ss << num << " " << unit[k] << suffix;
+	return ss.str();
 }

--- a/lib/base/estring.h
+++ b/lib/base/estring.h
@@ -36,4 +36,9 @@ std::string strip_non_graph(std::string s);
 std::vector<std::string> split(std::string s, const std::string& separator);
 int strcasecmp(const std::string& s1, const std::string& s2);
 
+std::string formatNumber(size_t size, const std::string& suffix={}, bool binary = false);
+inline std::string formatBits(size_t size) { return formatNumber(size, "bit"); }
+inline std::string formatBytes(size_t size) { return formatNumber(size, "B", true); }
+inline std::string formatHz(size_t size) { return formatNumber(size, "Hz"); }
+
 #endif // __E_STRING__


### PR DESCRIPTION
Add formatNumber and helper functions to display sizes in human readable format.

Eg.
size_t l = 80*1000;
printf("Bit %zu -> %s\n", l, formatBits(l).c_str());
l = 80LL*1024*1024*1024;
printf("Bytes %zu -> %s\n", l, formatBytes(l).c_str());
l = 80LL*1000*1000;
printf("Hz %zu -> %s\n", l, formatHz(l).c_str());
l = 80LL*1000*1000*1000*1000;
printf("Number %zu -> %s\n\n", l, formatNumber(l).c_str());

Will print:
Bit 80000 -> 80 kbit
Bytes 85899345920 -> 80 GB
Hz 80000000 -> 80 MHz
Number 80000000000000 -> 80 T