### PR TITLE
[startwizard.xml] Use the new time setting code

### DIFF
--- a/data/startwizard.xml
+++ b/data/startwizard.xml
@@ -377,13 +377,14 @@ self.selectKey("OK")
 		</step>
 
 		<step id="timeoptions" nextstep="wizardoptions">
-			<text value="Please set your time options" />
+			<text value="Please set your time options.\n\nPress YELLOW to set the time zone via geolocation." />
 			<displaytext value="Please set your time options" />
-			<config screen="Setup" module="Setup" args="time" type="ConfigList" />
+			<config screen="Time" module="Time" args="time" type="ConfigList" />
 			<code>
 self.clearSelectedKeys()
 self.selectKey("LEFT")
 self.selectKey("RIGHT")
+self.selectKey("YELLOW")
 			</code>
 		</step>
 


### PR DESCRIPTION
Allow the Welcome Wizard to access the new Time.py time setting code that also offers user selected access to geolocation to set the time zone automatically (based on a geolocation lookup).