### PR TITLE
Add BCM encoder changes from PLI (#570)

### DIFF
--- a/lib/dvb/demux.cpp
+++ b/lib/dvb/demux.cpp
@@ -412,13 +412,21 @@ RESULT eDVBPESReader::connectRead(const sigc::slot2<void,const uint8_t*,int> &r,
 	return 0;
 }
 
-eDVBRecordFileThread::eDVBRecordFileThread(int packetsize, int bufferCount):
+eDVBRecordFileThread::eDVBRecordFileThread(int packetsize, int bufferCount, int buffersize, bool sync_mode) :
+	/*
+	 * Note on buffer size: Usually this is calculated from packet size and an evaluated number of buffers.
+	 * for the Broadcom encoder we need to have a fixed buffer size though, so we must be able to override
+	 * the calculation. This could be faked by using a packet size of 47, but apparently other code
+	 * can't handle that and segfaults. If you want the "normal" behaviour, just use -1 (or leave it out
+	 * completely, the default declaration).
+	 */
 	eFilePushThreadRecorder(
-		/* buffer */ (unsigned char*) ::mmap(NULL, bufferCount * packetsize * 1024, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, /*ignored*/-1, 0),
-		/*buffersize*/ packetsize * 1024),
+		/*buffer*/ (unsigned char*) ::mmap(NULL, (buffersize > 0) ? (buffersize * bufferCount) : (bufferCount * packetsize * 1024), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, /*ignored*/-1, 0),
+		/*buffersize*/ (buffersize > 0) ? buffersize : (packetsize * 1024)),
 	 m_ts_parser(packetsize),
 	 m_current_offset(0),
 	 m_fd_dest(-1),
+	 m_sync_mode(sync_mode),
 	 m_aio(bufferCount),
 	 m_current_buffer(m_aio.begin()),
 	 m_buffer_use_histogram(bufferCount+1, 0)
@@ -479,7 +487,7 @@ int eDVBRecordFileThread::AsyncIO::wait()
 			int r = aio_suspend(&paio, 1, NULL);
 			if (r < 0)
 			{
-				eDebug("[eDVBRecordFileThread] aio_suspend failed: %m");
+				eWarning("[eDVBRecordFileThread] aio_suspend failed: %m");
 				return -1;
 			}
 		}
@@ -487,7 +495,7 @@ int eDVBRecordFileThread::AsyncIO::wait()
 		aio.aio_buf = NULL;
 		if (r < 0)
 		{
-			eDebug("[eDVBRecordFileThread] wait: aio_return returned failure: %m");
+			eWarning("[eDVBRecordFileThread] wait: aio_return returned failure: %m");
 			return -1;
 		}
 	}
@@ -515,7 +523,7 @@ int eDVBRecordFileThread::AsyncIO::poll()
 	aio.aio_buf = NULL;
 	if (r < 0)
 	{
-		eDebug("[eDVBRecordFileThread] poll: aio_return returned failure: %m");
+		eWarning("[eDVBRecordFileThread] poll: aio_return returned failure: %d %m", r);
 		return -1;
 	}
 	return 0;
@@ -552,7 +560,7 @@ int eDVBRecordFileThread::asyncWrite(int len)
 	int r = m_current_buffer->start(m_fd_dest, m_current_offset, len, m_buffer);
 	if (r < 0)
 	{
-		eDebug("[eDVBRecordFileThread] aio_write failed: %m");
+		eWarning("[eDVBRecordFileThread] aio_write failed: %m");
 		return r;
 	}
 	m_current_offset += len;
@@ -575,12 +583,15 @@ int eDVBRecordFileThread::asyncWrite(int len)
 		--i;
 		if (i == m_current_buffer)
 		{
-			eDebug("[eFilePushThreadRecorder] Warning: All write buffers busy");
+			eWarning("[eFilePushThreadRecorder] Warning: All write buffers busy");
 			break;
 		}
 		r = i->poll();
 		if (r < 0)
+		{
+			eWarning("[eDVBRecordFileThread] poll failed: %d", r);
 			return r;
+		}
 	}
 	++m_buffer_use_histogram[busy_count];
 
@@ -593,14 +604,45 @@ int eDVBRecordFileThread::asyncWrite(int len)
 
 int eDVBRecordFileThread::writeData(int len)
 {
-	len = asyncWrite(len);
-	if (len < 0)
-		return len;
-	// Wait for previous aio to complete on this buffer before returning
-	int r = m_current_buffer->wait();
-	if (r < 0)
-		return -1;
-	return len;
+	if(m_sync_mode)
+	{
+		struct pollfd pfd;
+
+		pfd.fd = m_fd_dest;
+		pfd.events = POLLOUT;
+		poll(&pfd, 1, -1);
+
+		len = write(m_fd_dest, m_buffer, len);
+
+		if(len < 0)
+		{
+			eWarning("[eDVBRecordFileThread] writedata write error: %d %m", len);
+			return(len);
+		}
+
+		if(len == 0)
+		{
+			eWarning("[eDVBRecordFileThread] writedata write eof: %d %m", len);
+			return(len);
+		}
+	}
+	else
+	{
+		len = asyncWrite(len);
+		if (len < 0)
+		{
+			eWarning("[eDVBRecordFileThread] asyncwrite failed: %d", len);
+			return len;
+		}
+		// Wait for previous aio to complete on this buffer before returning
+		int r = m_current_buffer->wait();
+		if (r < 0)
+		{
+			eWarning("[eDVBRecordFileThread] wait failed: %d\n", len);
+			return -1;
+		}
+	}
+	return(len);
 }
 
 void eDVBRecordFileThread::flush()
@@ -627,46 +669,75 @@ void eDVBRecordFileThread::flush()
 	}
 }
 
-eDVBRecordStreamThread::eDVBRecordStreamThread(int packetsize) :
-	eDVBRecordFileThread(packetsize, recordingBufferCount)
+eDVBRecordStreamThread::eDVBRecordStreamThread(int packetsize, int buffersize, bool sync_mode) :
+	eDVBRecordFileThread(packetsize, recordingBufferCount, buffersize, sync_mode)
 {
 	eDebug("[eDVBRecordStreamThread] allocated %zu buffers of %zu kB", m_aio.size(), m_buffersize>>10);
 }
 
 int eDVBRecordStreamThread::writeData(int len)
 {
-	len = asyncWrite(len);
-	if (len < 0)
-		return len;
-	// Cancel aio on this buffer before returning, streams should not be held up. So we CANCEL
-	// any request that hasn't finished on the second round.
-	int r = m_current_buffer->cancel(m_fd_dest);
-	switch (r)
+	if(m_sync_mode)
 	{
-		//case 0: // that's one of these two:
-		case AIO_CANCELED:
-		case AIO_ALLDONE:
-			break;
-		case AIO_NOTCANCELED:
-			eDebug("[eDVBRecordStreamThread] failed to cancel, killing all waiting IO");
-			aio_cancel(m_fd_dest, NULL);
-			// Poll all open requests, because they are all in error state now.
-			for (AsyncIOvector::iterator it = m_aio.begin(); it != m_aio.end(); ++it)
-			{
-				it->poll();
-			}
-			break;
-		case -1:
-			eDebug("[eDVBRecordStreamThread] failed: %m");
-			return r;
+		struct pollfd pfd;
+
+		pfd.fd = m_fd_dest;
+		pfd.events = POLLOUT;
+		poll(&pfd, 1, -1);
+
+		len = write(m_fd_dest, m_buffer, len);
+
+		if(len < 0)
+		{
+			eWarning("[eDVBRecordStreamThread] writedata write error: %d %m", len);
+			return(len);
+		}
+
+		if(len == 0)
+		{
+			eWarning("[eDVBRecordStreamFileThread] writedata write eof: %d %m", len);
+			return(len);
+		}
 	}
-	// we want to have a consistent state, so wait for completion, just to be sure
-	r = m_current_buffer->wait();
-	if (r < 0)
+	else
 	{
-		eDebug("[eDVBRecordStreamThread] wait failed: %m");
-		return -1;
+		len = asyncWrite(len);
+		if (len < 0)
+		{
+			eWarning("[eDVBRecordStreamThread] asyncWrite returns %d\n", len);
+			return len;
+		}
+		// Cancel aio on this buffer before returning, streams should not be held up. So we CANCEL
+		// any request that hasn't finished on the second round.
+		int r = m_current_buffer->cancel(m_fd_dest);
+		switch (r)
+		{
+			//case 0: // that's one of these two:
+			case AIO_CANCELED:
+			case AIO_ALLDONE:
+				break;
+			case AIO_NOTCANCELED:
+				eDebug("[eDVBRecordStreamThread] failed to cancel, killing all waiting IO");
+				aio_cancel(m_fd_dest, NULL);
+				// Poll all open requests, because they are all in error state now.
+				for (AsyncIOvector::iterator it = m_aio.begin(); it != m_aio.end(); ++it)
+				{
+					it->poll();
+				}
+				break;
+			case -1:
+				eDebug("[eDVBRecordStreamThread] failed: %m");
+				return r;
+		}
+		// we want to have a consistent state, so wait for completion, just to be sure
+		r = m_current_buffer->wait();
+		if (r < 0)
+		{
+			eDebug("[eDVBRecordStreamThread] wait failed: %m");
+			return -1;
+		}
 	}
+
 	return len;
 }
 

--- a/lib/dvb/demux.h
+++ b/lib/dvb/demux.h
@@ -50,7 +50,6 @@ private:
 	friend class eDVBCAService;
 	friend class eTSMPEGDecoder;
 	sigc::signal1<void, int> m_event;
-
 	int openDemux(void);
 };
 
@@ -94,7 +93,7 @@ public:
 class eDVBRecordFileThread: public eFilePushThreadRecorder
 {
 public:
-	eDVBRecordFileThread(int packetsize, int bufferCount);
+	eDVBRecordFileThread(int packetsize, int bufferCount, int buffersize = -1, bool sync_mode = false);
 	~eDVBRecordFileThread();
 	void setTimingPID(int pid, iDVBTSRecorder::timing_pid_type pidtype, int streamtype);
 	void startSaveMetaInformation(const std::string &filename);
@@ -125,6 +124,7 @@ protected:
 	eMPEGStreamParserTS m_ts_parser;
 	off_t m_current_offset;
 	int m_fd_dest;
+	bool m_sync_mode;
 	typedef std::vector<AsyncIO> AsyncIOvector;
 	unsigned char* m_allocated_buffer;
 	AsyncIOvector m_aio;
@@ -135,7 +135,8 @@ protected:
 class eDVBRecordStreamThread: public eDVBRecordFileThread
 {
 public:
-	eDVBRecordStreamThread(int packetsize);
+	eDVBRecordStreamThread(int packetsize, int buffersize = -1, bool sync_mode = false);
+
 protected:
 	int writeData(int len);
 	void flush();

--- a/lib/dvb/encoder.cpp
+++ b/lib/dvb/encoder.cpp
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/ioctl.h>
 
 #include <lib/base/eerror.h>
 #include <lib/base/init.h>
@@ -12,6 +13,7 @@
 #include <lib/base/cfile.h>
 #include <lib/nav/core.h>
 #include <lib/dvb/encoder.h>
+#include <lib/dvb/pmt.h>
 #include <lib/service/service.h>
 
 DEFINE_REF(eEncoder);
@@ -25,113 +27,389 @@ eEncoder *eEncoder::getInstance()
 
 eEncoder::eEncoder()
 {
-	instance = this;
+	int decoder_index;
 	ePtr<iServiceHandler> service_center;
+	eNavigation *navigation_instance;
+
+	instance = this;
 	eServiceCenter::getInstance(service_center);
-	if (service_center)
+
+	if(service_center)
 	{
-		int index = 0;
-		while (1)
+		bcm_encoder = bool(CFile("/dev/bcm_enc0", "r"));
+
+		/*
+		 * The Broadcom transcoding engine does not transfer the data to the encoder
+		 * itself, so we need to start a thread to do that. Therefore there is no
+		 * use to connect a (valid) decoder device. Even more it won't work because
+		 * we can't open the encoder when more than two (main, PiP) decoders are in
+		 * use. The encoder is reported as "busy" then. That's why we use dummy values
+		 * here (4 onwards).
+		 *
+		 * OTOH the "xtrend" transcoding engine has the video decoder connected to
+		 * the selected encoder internally. So we need to use the right decoder,
+		 * connected to the selected encoder. This is usually 2 -> 0, 3 -> 1.
+		 */
+
+		for(int index = 0; index < 4; index++) // increase this if machines appear with more than 4 encoding engines
 		{
-			int decoderindex;
-			char filename[256];
+			char filename[64];
+
 			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/decoder", index);
-			if (CFile::parseInt(&decoderindex, filename) < 0) break;
-			navigationInstances.push_back(new eNavigation(service_center, decoderindex));
-			encoderUser.push_back(-1);
-			index++;
+
+			if (CFile::parseInt(&decoder_index, filename) < 0)
+				break;
+
+			if(bcm_encoder)
+				decoder_index = index + 4;
+
+			if((navigation_instance = new eNavigation(service_center, decoder_index)) == nullptr)
+				break;
+
+			encoder.push_back(EncoderContext(index, decoder_index, navigation_instance));
 		}
 	}
 }
 
 eEncoder::~eEncoder()
 {
-	instance = NULL;
+	for(int encoder_index = 0; encoder_index < (int)encoder.size(); encoder_index++)
+	{
+		encoder[encoder_index].state = EncoderContext::state_destroyed;
+		encoder[encoder_index].navigation_instance = nullptr; /* apparently we're not allowed to delete */
+	}
+
+	instance = nullptr;
 }
 
-int eEncoder::allocateEncoder(const std::string &serviceref, const int bitrate, const int width, const int height, const int framerate, const int interlaced, const int aspectratio, const std::string &vcodec, const std::string &acodec)
+int eEncoder::allocateEncoder(const std::string &serviceref, int &buffersize,
+		int bitrate, int width, int height, int framerate, int interlaced, int aspectratio,
+		const std::string &vcodec, const std::string &acodec)
 {
-	unsigned int i;
-	int encoderfd = -1;
-	for (i = 0; i < encoderUser.size(); i++)
+	static const char fileref[] = "1:0:1:0:0:0:0:0:0:0:";
+	int encoder_index;
+	char filename[128];
+	std::string source_file;
+	const char *vcodec_node;
+	const char *acodec_node;
+
+	eDebug("[eEncoder] allocateEncoder serviceref=%s bitrate=%d width=%d height=%d vcodec=%s acodec=%s",
+			serviceref.c_str(), bitrate, width, height, vcodec.c_str(), acodec.c_str());
+
+	if(bcm_encoder)
 	{
-		if (encoderUser[i] < 0)
-		{
-			char filename[128];
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/bitrate", i);
-			CFile::writeInt(filename, bitrate);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/width", i);
-			CFile::writeInt(filename, width);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/height", i);
-			CFile::writeInt(filename, height);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/framerate", i);
-			CFile::writeInt(filename, framerate);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/interlaced", i);
-			CFile::writeInt(filename, interlaced);
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/aspectratio", i);
-			CFile::writeInt(filename, aspectratio);
-			if (!vcodec.empty())
-			{
-				snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/vcodec_choices", i);
-				if (CFile::contains_word(filename, vcodec))
-				{
-					snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/vcodec", i);
-					CFile::write(filename, vcodec.c_str());
-				}
-			}
-			if (!acodec.empty())
-			{
-				snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/acodec_choices", i);
-				if (CFile::contains_word(filename, acodec))
-				{
-					snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/acodec", i);
-					CFile::write(filename, acodec.c_str());
-				}
-			}
-			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/apply", i);
-			CFile::writeInt(filename, 1);
-			if (navigationInstances[i]->playService(serviceref) >= 0)
-			{
-				snprintf(filename, sizeof(filename), "/dev/encoder%d", i);
-				encoderfd = open(filename, O_RDONLY);
-				encoderUser[i] = encoderfd;
-			}
+		vcodec_node = "video_codec";
+		acodec_node = "audio_codec";
+	}
+	else
+	{
+		vcodec_node = "vcodec";
+		acodec_node = "acodec";
+	}
+
+	// extract file path from serviceref, this is needed for Broadcom transcoding
+	if(serviceref.compare(0, sizeof(fileref) - 1, std::string(fileref), 0, std::string::npos) == 0)
+		source_file = serviceref.substr(sizeof(fileref) - 1, std::string::npos);
+
+	eDebug("[allocateEncoder] serviceref: %s", serviceref.c_str());
+	eDebug("[allocateEncoder] serviceref substr: %s", serviceref.substr(0, sizeof(fileref) - 1).c_str());
+	eDebug("[allocateEncoder] source_file: \"%s\"", source_file.c_str());
+
+	for(encoder_index = 0; encoder_index < (int)encoder.size(); encoder_index++)
+		if(encoder[encoder_index].state == EncoderContext::state_idle)
 			break;
+
+	if(encoder_index >= (int)encoder.size())
+	{
+		eWarning("[eEncoder] no encoders free");
+		return(-1);
+	}
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/bitrate", encoder_index);
+	CFile::writeInt(filename, bitrate);
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/width", encoder_index);
+	CFile::writeInt(filename, width);
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/height", encoder_index);
+	CFile::writeInt(filename, height);
+
+	if(bcm_encoder)
+	{
+		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/display_format", encoder_index);
+
+		if(height > 576)
+			CFile::write(filename, "720p");
+		else
+			if(height > 480)
+				CFile::write(filename, "576p");
+			else
+				CFile::write(filename, "480p");
+	}
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/framerate", encoder_index);
+	CFile::writeInt(filename, framerate);
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/interlaced", encoder_index);
+	CFile::writeInt(filename, interlaced);
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/aspectratio", encoder_index);
+	CFile::writeInt(filename, aspectratio);
+
+	if(!vcodec.empty())
+	{
+		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/%s_choices", encoder_index, vcodec_node);
+		if (CFile::contains_word(filename, vcodec))
+		{
+			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/%s", encoder_index, vcodec_node);
+			CFile::write(filename, vcodec.c_str());
 		}
 	}
-	return encoderfd;
+
+	if(!acodec.empty())
+	{
+		snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/%s_choices", encoder_index, acodec_node);
+		if (CFile::contains_word(filename, acodec))
+		{
+			snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/%s", encoder_index, acodec_node);
+			CFile::write(filename, acodec.c_str());
+		}
+	}
+
+	snprintf(filename, sizeof(filename), "/proc/stb/encoder/%d/apply", encoder_index);
+	CFile::writeInt(filename, 1);
+
+	if(encoder[encoder_index].navigation_instance->playService(serviceref) < 0)
+	{
+		eWarning("[eEncoder] navigation->playservice failed");
+		return(-1);
+	}
+
+	if(!source_file.empty() && ((encoder[encoder_index].file_fd = open(source_file.c_str(), O_RDONLY, 0)) < 0))
+	{
+		eWarning("[eEncoder] open source file failed");
+		return(-1);
+	}
+
+	snprintf(filename, sizeof(filename), "/dev/%s%d", bcm_encoder ? "bcm_enc" : "encoder", encoder_index);
+
+	if((encoder[encoder_index].encoder_fd = open(filename, bcm_encoder ? O_RDWR : O_RDONLY)) < 0)
+	{
+		eWarning("[eEncoder] open encoder failed");
+		return(-1);
+	}
+
+	if(bcm_encoder)
+	{
+		buffersize = 188 * 256; /* broadcom magic value */
+		encoder[encoder_index].state = EncoderContext::state_wait_pmt;
+
+		switch(encoder_index)
+		{
+			case(0):
+			{
+				encoder[encoder_index].navigation_instance->connectEvent(sigc::mem_fun(*this, &eEncoder::navigation_event_0), m_nav_event_connection_0);
+				break;
+			}
+
+			case(1):
+			{
+				encoder[encoder_index].navigation_instance->connectEvent(sigc::mem_fun(*this, &eEncoder::navigation_event_1), m_nav_event_connection_1);
+				break;
+			}
+
+			default:
+			{
+				eWarning("[eEncoder] only encoder 0 and encoder 1 implemented");
+				break;
+			}
+		}
+	}
+	else
+	{
+		buffersize = -1;
+		encoder[encoder_index].state = EncoderContext::state_running;
+	}
+
+	return(encoder[encoder_index].encoder_fd);
 }
 
 void eEncoder::freeEncoder(int encoderfd)
 {
-	unsigned int i;
-	for (i = 0; i < encoderUser.size(); i++)
+	int encoder_index;
+	ePtr<iPlayableService> service;
+	ePtr<iTapService> tservice;
+
+	if(encoderfd < 0)
 	{
-		if (encoderUser[i] == encoderfd)
-		{
-			encoderUser[i] = -1;
-			if (navigationInstances[i])
-			{
-				navigationInstances[i]->stopService();
-			}
+		eWarning("[eEncoder] trying to release incorrect encoder %d", encoderfd);
+		return;
+	}
+
+	for(encoder_index = 0; encoder_index < (int)encoder.size(); encoder_index++)
+		if(encoder[encoder_index].encoder_fd == encoderfd)
 			break;
+
+	if(encoder_index >= (int)encoder.size())
+	{
+		eWarning("[eEncoder] encoder with fd=%d not found", encoderfd);
+		return;
+	}
+
+	switch(encoder[encoder_index].state)
+	{
+		case(EncoderContext::state_idle):
+		case(EncoderContext::state_finishing):
+		case(EncoderContext::state_destroyed):
+		{
+			eWarning("[eEncoder] trying to release inactive encoder %d fd=%d, state=%d", encoder_index, encoderfd, encoder[encoder_index].state);
+			return;
 		}
 	}
-	if (encoderfd >= 0) ::close(encoderfd);
+
+	if(encoder[encoder_index].stream_thread != nullptr)
+	{
+		encoder[encoder_index].stream_thread->stop();
+		delete encoder[encoder_index].stream_thread;
+		encoder[encoder_index].stream_thread = nullptr;
+	}
+
+	encoder[encoder_index].state = EncoderContext::state_finishing;
+	encoder[encoder_index].kill();
+
+	encoder[encoder_index].navigation_instance->getCurrentService(service);
+	service->tap(tservice);
+	tservice->stopTapToFD();
+
+	encoder[encoder_index].navigation_instance->stopService();
+
+	close(encoder[encoder_index].encoder_fd);
+	close(encoder[encoder_index].file_fd);
+	encoder[encoder_index].encoder_fd = -1;
+	encoder[encoder_index].file_fd = -1;
+
+	encoder[encoder_index].state = EncoderContext::state_idle;
 }
 
 int eEncoder::getUsedEncoderCount()
 {
 	int count = 0;
-	unsigned int i;
-	for (i = 0; i < encoderUser.size(); i++)
+
+	for(int encoder_index = 0; encoder_index < (int)encoder.size(); encoder_index++)
 	{
-		if (encoderUser[i] >= 0)
+		switch(encoder[encoder_index].state)
 		{
-			count++;
+			case(EncoderContext::state_running):
+			case(EncoderContext::state_wait_pmt):
+			{
+				count++;
+				break;
+			}
 		}
 	}
-	return count;
+
+	return(count);
+}
+
+void eEncoder::navigation_event(int encoder_index, int event)
+{
+	eDebug("[eEncoder] navigation event: %d %d", encoder_index, event);
+
+	if((encoder_index < 0) || (encoder_index >= (int)encoder.size()))
+		return;
+
+	if(event == eDVBServicePMTHandler::eventTuned)
+	{
+		eDebug("[eEncoder] navigation event tuned: %d %d", encoder_index, event);
+
+		if(encoder[encoder_index].state == EncoderContext::state_wait_pmt)
+		{
+			ePtr<iPlayableService> service;
+			ePtr<iTapService> tservice;
+			ePtr<iServiceInformation> info;
+			std::vector<int> pids;
+
+			encoder[encoder_index].navigation_instance->getCurrentService(service);
+			service->info(info);
+
+			int vpid = info->getInfo(iServiceInformation::sVideoPID);
+			int apid = info->getInfo(iServiceInformation::sAudioPID);
+			int pmtpid = info->getInfo(iServiceInformation::sPMTPID);
+
+			if((vpid > 0) && (apid > 0) && (pmtpid > 0))
+			{
+				eDebug("[eEncoder] info complete: %d, %d, %d", vpid, apid, pmtpid);
+
+				pids.push_back(pmtpid);
+				pids.push_back(vpid);
+				pids.push_back(apid);
+
+				if(encoder[encoder_index].file_fd < 0)
+				{
+					service->tap(tservice);
+
+					if(tservice == nullptr)
+					{
+						eWarning("[eEncoder] tap service failed");
+						freeEncoder(encoder[encoder_index].encoder_fd);
+						return;
+					}
+
+					tservice->startTapToFD(encoder[encoder_index].encoder_fd, pids);
+				}
+				else
+				{
+					if(encoder[encoder_index].stream_thread != nullptr)
+					{
+						eWarning("[eEncoder] datapump already running");
+						return;
+					}
+
+					encoder[encoder_index].stream_thread = new eDVBRecordStreamThread(188, -1, true);
+
+					encoder[encoder_index].stream_thread->setTargetFD(encoder[encoder_index].encoder_fd);
+					encoder[encoder_index].stream_thread->start(encoder[encoder_index].file_fd);
+				}
+
+				if(ioctl(encoder[encoder_index].encoder_fd, IOCTL_BROADCOM_SET_PMTPID_MIPS, pmtpid) ||
+						ioctl(encoder[encoder_index].encoder_fd, IOCTL_BROADCOM_SET_VPID_MIPS, vpid) ||
+						ioctl(encoder[encoder_index].encoder_fd, IOCTL_BROADCOM_SET_APID_MIPS, apid))
+				{
+					eDebug("[eEncoder] set ioctl(mips) failed");
+
+					if(ioctl(encoder[encoder_index].encoder_fd, IOCTL_BROADCOM_SET_PMTPID_ARM, pmtpid) ||
+							ioctl(encoder[encoder_index].encoder_fd, IOCTL_BROADCOM_SET_VPID_ARM, vpid) ||
+							ioctl(encoder[encoder_index].encoder_fd, IOCTL_BROADCOM_SET_APID_ARM, apid))
+					{
+						eWarning("[eEncoder] set ioctl(arm) failed too, giving up");
+						freeEncoder(encoder[encoder_index].encoder_fd);
+						return;
+					}
+				}
+
+				encoder[encoder_index].state = EncoderContext::state_running;
+				encoder[encoder_index].run();
+			}
+		}
+	}
+}
+
+void eEncoder::navigation_event_0(int event)
+{
+	navigation_event(0, event);
+}
+
+void eEncoder::navigation_event_1(int event)
+{
+	navigation_event(1, event);
+}
+
+void eEncoder::EncoderContext::thread(void)
+{
+	hasStarted();
+
+	if(ioctl(encoder_fd, IOCTL_BROADCOM_START_TRANSCODING, 0))
+		eWarning("[eEncoder] thread encoder failed");
 }
 
 eAutoInitPtr<eEncoder> init_eEncoder(eAutoInitNumbers::service + 1, "Encoders");

--- a/lib/dvb/encoder.h
+++ b/lib/dvb/encoder.h
@@ -4,25 +4,83 @@
 #include <vector>
 
 #include <lib/nav/core.h>
+#include <lib/dvb/streamserver.h>
 
 class eEncoder
 {
-	DECLARE_REF(eEncoder);
+	private:
 
-	std::vector<eNavigation *> navigationInstances;
-	std::vector<int> encoderUser;
+		DECLARE_REF(eEncoder);
 
-	static eEncoder *instance;
+		enum
+		{
+			IOCTL_BROADCOM_SET_VPID_MIPS = 1,
+			IOCTL_BROADCOM_SET_VPID_ARM = 11,
+			IOCTL_BROADCOM_SET_APID_MIPS = 2,
+			IOCTL_BROADCOM_SET_APID_ARM = 12,
+			IOCTL_BROADCOM_SET_PMTPID_MIPS = 3,
+			IOCTL_BROADCOM_SET_PMTPID_ARM = 13,
+			IOCTL_BROADCOM_START_TRANSCODING = 100,
+			IOCTL_BROADCOM_STOP_TRANSCODING = 200,
+		};
 
-public:
-	eEncoder();
-	~eEncoder();
+		class EncoderContext : public eThread
+		{
+			public:
 
-	int allocateEncoder(const std::string &serviceref, const int bitrate, const int width, const int height, const int framerate, const int interlaced, const int aspectratio, const std::string &vcodec = "", const std::string &acodec = "");
-	void freeEncoder(int encoderfd);
-	int getUsedEncoderCount();
+				EncoderContext(int encoder_index_in, int decoder_index_in, eNavigation *navigation_instance_in)
+				{
+					encoder_index = encoder_index_in;
+					decoder_index = decoder_index_in;
+					file_fd = -1;
+					encoder_fd = -1;
+					state = state_idle;
+					navigation_instance = navigation_instance_in;
+					stream_thread = nullptr;
+				}
 
-	static eEncoder *getInstance();
+				int encoder_index;
+				int decoder_index;
+				int encoder_fd;
+				int file_fd;
+				eDVBRecordStreamThread *stream_thread;
+
+				enum
+				{
+					state_idle,
+					state_wait_pmt,
+					state_running,
+					state_finishing,
+					state_destroyed,
+				} state;
+
+				eNavigation *navigation_instance;
+
+				void thread(void);
+		};
+
+		std::vector<EncoderContext> encoder;
+		bool bcm_encoder;
+		ePtr<eConnection> m_nav_event_connection_0;
+		ePtr<eConnection> m_nav_event_connection_1;
+
+		static eEncoder *instance;
+
+		void navigation_event_0(int);
+		void navigation_event_1(int);
+		void navigation_event(int, int);
+
+	public:
+
+		eEncoder();
+		~eEncoder();
+
+		int allocateEncoder(const std::string &serviceref, int &buffersize, int bitrate, int width, int height, int framerate, int interlaced, int aspectratio,
+				const std::string &vcodec = "", const std::string &acodec = "");
+		void freeEncoder(int encoderfd);
+		int getUsedEncoderCount();
+
+		static eEncoder *getInstance();
 };
 
 #endif /* __DVB_ENCODER_H_ */

--- a/lib/dvb/filepush.cpp
+++ b/lib/dvb/filepush.cpp
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <poll.h>
 
 //#define SHOW_WRITE_TIME
 
@@ -343,6 +344,13 @@ void eFilePushThreadRecorder::thread()
 	/* m_stop must be evaluated after each syscall. */
 	while (!m_stop)
 	{
+		/* this works around the buggy Broadcom encoder that always returns even if there is no data */
+		/* (works like O_NONBLOCK even when not opened as such), prevent idle waiting for the data */
+		/* this won't ever hurt, because it will return immediately when there is data or an error condition */
+
+		struct pollfd pfd = { m_fd_source, POLLIN, 0 };
+		poll(&pfd, 1, 100);
+
 		ssize_t bytes = ::read(m_fd_source, m_buffer, m_buffersize);
 		if (bytes < 0)
 		{
@@ -380,7 +388,7 @@ void eFilePushThreadRecorder::thread()
 #endif
 		if (w < 0)
 		{
-			eDebug("[eFilePushThreadRecorder] WRITE ERROR, aborting thread: %m");
+			eWarning("[eFilePushThreadRecorder] WRITE ERROR, aborting thread: %m");
 			sendEvent(evtWriteError);
 			break;
 		}

--- a/lib/dvb/streamserver.cpp
+++ b/lib/dvb/streamserver.cpp
@@ -160,7 +160,8 @@ void eStreamClient::notifier(int what)
 				set_tcp_option(streamFd, TCP_USER_TIMEOUT, 10 * 1000);
 
 				if (serviceref.substr(0, 10) == "file?file=") /* convert openwebif stream reqeust back to serviceref */
-					serviceref = "1:0:1:0:0:0:0:0:0:0:" + serviceref.substr(10);
+					serviceref = std::string("1:0:1:0:0:0:0:0:0:0:") + serviceref.substr(10);
+
 				pos = serviceref.find('?');
 				if (pos == std::string::npos)
 				{
@@ -209,7 +210,9 @@ void eStreamClient::notifier(int what)
 						int framerate = 25000;
 						int interlaced = 0;
 						int aspectratio = 0;
+						int buffersize;
 						std::string vcodec, acodec;
+
 						sscanf(request.substr(pos).c_str(), "&bitrate=%d", &bitrate);
 						pos = request.find("&width=");
 						if (pos != std::string::npos)
@@ -246,20 +249,26 @@ void eStreamClient::notifier(int what)
 								acodec = acodec.substr(0, pos);
 							}
 						}
+
 						encoderFd = -1;
-						if (eEncoder::getInstance())
-							encoderFd = eEncoder::getInstance()->allocateEncoder(serviceref, bitrate, width, height, framerate, !!interlaced, aspectratio, vcodec, acodec);
-						if (encoderFd >= 0)
+
+						if(eEncoder::getInstance())
+							encoderFd = eEncoder::getInstance()->allocateEncoder(serviceref, buffersize, bitrate, width, height, framerate, !!interlaced, aspectratio,
+									vcodec, acodec);
+
+						if(encoderFd >= 0)
 						{
-							running = true;
-							streamThread = new eDVBRecordStreamThread(188);
+							m_serviceref = serviceref;
+							m_useencoder = true;
+
+							streamThread = new eDVBRecordStreamThread(188, buffersize);
+
 							if (streamThread)
 							{
 								streamThread->setTargetFD(streamFd);
 								streamThread->start(encoderFd);
+								running = true;
 							}
-							m_serviceref = serviceref;
-							m_useencoder = true;
 						}
 					}
 				}

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -653,6 +653,19 @@ public:
 };
 SWIG_TEMPLATE_TYPEDEF(ePtr<iTimeshiftService>, iTimeshiftServicePtr);
 
+SWIG_IGNORE(iTapService);
+class iTapService: public iObject
+{
+#ifdef SWIG
+	iTapService();
+	~iTapService();
+#endif
+public:
+	virtual bool startTapToFD(int fd, const std::vector<int> &pids, int packetsize = 188)=0;
+	virtual void stopTapToFD()=0;
+};
+SWIG_TEMPLATE_TYPEDEF(ePtr<iTapService>, iTapServicePtr);
+
 	/* not related to eCueSheet */
 
 class iCueSheet_ENUMS
@@ -963,6 +976,7 @@ public:
 	virtual SWIG_VOID(RESULT) subServices(ePtr<iSubserviceList> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) frontendInfo(ePtr<iFrontendInformation> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) timeshift(ePtr<iTimeshiftService> &SWIG_OUTPUT)=0;
+	virtual SWIG_VOID(RESULT) tap(ePtr<iTapService> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) cueSheet(ePtr<iCueSheet> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) subtitle(ePtr<iSubtitleOutput> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) audioDelay(ePtr<iAudioDelay> &SWIG_OUTPUT)=0;

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1032,6 +1032,7 @@ eDVBServicePlay::eDVBServicePlay(const eServiceReference &ref, eDVBService *serv
 	m_skipmode(0),
 	m_fastforward(0),
 	m_slowmotion(0),
+	m_tap_recorder(0),
 	m_cuesheet_changed(0),
 	m_cutlist_enabled(1),
 	m_subtitle_widget(0),
@@ -1767,6 +1768,12 @@ RESULT eDVBServicePlay::timeshift(ePtr<iTimeshiftService> &ptr)
 		return 0;
 	}
 	return -1;
+}
+
+RESULT eDVBServicePlay::tap(ePtr<iTapService> &ptr)
+{
+	ptr = this;
+	return 0;
 }
 
 RESULT eDVBServicePlay::cueSheet(ePtr<iCueSheet> &ptr)
@@ -2648,6 +2655,49 @@ std::string eDVBServicePlay::getTimeshiftFilename()
 		return m_timeshift_file;
 	else
 		return "";
+}
+
+bool eDVBServicePlay::startTapToFD(int fd, const std::vector<int> &pids, int packetsize)
+{
+	ePtr<iDVBDemux> demux;
+
+	eDebug("[eServiceTap] start tap");
+
+	if(m_tap_recorder)
+	{
+		eWarning("[eServiceTap] tap already running");
+		return(false);
+	}
+
+	if (m_service_handler.getDataDemux(demux))
+		return(false);
+
+	demux->createTSRecorder(m_tap_recorder, packetsize, false);
+
+	if(m_tap_recorder == nullptr)
+	{
+		eWarning("[eServiceTap] tap create recorder failed");
+		return(false);
+	}
+
+	m_tap_recorder->setTargetFD(fd);
+	m_tap_recorder->enableAccessPoints(false);
+
+	for(auto i : pids)
+		m_tap_recorder->addPID(i);
+
+	m_tap_recorder->start();
+
+	return(true);
+}
+
+void eDVBServicePlay::stopTapToFD()
+{
+	if(m_tap_recorder != nullptr)
+	{
+		m_tap_recorder->stop();
+		m_tap_recorder = nullptr;
+	}
 }
 
 PyObject *eDVBServicePlay::getCutList()

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -86,7 +86,7 @@ class eDVBServicePlay: public eDVBServiceBase,
 		public iPlayableService, public iPauseableService,
 		public iSeekableService, public sigc::trackable, public iServiceInformation,
 		public iAudioTrackSelection, public iAudioChannelSelection,
-		public iSubserviceList, public iTimeshiftService,
+		public iSubserviceList, public iTimeshiftService, public iTapService,
 		public iCueSheet, public iSubtitleOutput, public iAudioDelay,
 		public iRdsDecoder, public iStreamableService,
 		public iStreamedService
@@ -109,6 +109,7 @@ public:
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr);
 	RESULT subServices(ePtr<iSubserviceList> &ptr);
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr);
+	RESULT tap(ePtr<iTapService> &ptr);
 	RESULT cueSheet(ePtr<iCueSheet> &ptr);
 	RESULT subtitle(ePtr<iSubtitleOutput> &ptr);
 	RESULT audioDelay(ePtr<iAudioDelay> &ptr);
@@ -174,6 +175,10 @@ public:
 	RESULT saveTimeshiftFile();
 	std::string getTimeshiftFilename();
 	void switchToLive();
+
+		// iTapService
+	bool startTapToFD(int fd, const std::vector<int> &pids, int packetsize = 188);
+	void stopTapToFD();
 
 		// iCueSheet
 	PyObject *getCutList();
@@ -253,6 +258,10 @@ protected:
 	int m_skipmode;
 	int m_fastforward;
 	int m_slowmotion;
+
+		/* tap */
+
+	ePtr<iDVBTSRecorder> m_tap_recorder;
 
 		/* cuesheet */
 

--- a/lib/service/servicedvd.h
+++ b/lib/service/servicedvd.h
@@ -71,6 +71,7 @@ public:
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = nullptr; return -1; }
 	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = nullptr; return -1; }
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = nullptr; return -1; }
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
 	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = nullptr; return -1; }
 	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; }
 	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; }

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -247,9 +247,11 @@ RESULT eServiceHDMIRecord::stop()
 
 int eServiceHDMIRecord::doPrepare()
 {
+	int buffersize; /* unused here */
+
 	if (!m_simulate && m_encoder_fd < 0)
 	{
-		if (eEncoder::getInstance()) m_encoder_fd = eEncoder::getInstance()->allocateEncoder(m_ref.toString(), 8 * 1024 * 1024, 1280, 720, 25000, false, 0);
+		if (eEncoder::getInstance()) m_encoder_fd = eEncoder::getInstance()->allocateEncoder(m_ref.toString(), buffersize, 8 * 1024 * 1024, 1280, 720, 25000, 0, 0);
 		if (m_encoder_fd < 0) return -1;
 	}
 	m_state = statePrepared;

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -58,6 +58,7 @@ public:
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = nullptr; return -1; }
 	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = nullptr; return -1; }
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = nullptr; return -1; }
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
 	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = nullptr; return -1; }
 
 	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; }

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -149,6 +149,7 @@ public:
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
 	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
 //	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = 0; return -1; }
 
 		// iCueSheet

--- a/lib/service/servicets.h
+++ b/lib/service/servicets.h
@@ -72,6 +72,7 @@ public:
 	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; };
 	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = nullptr; return -1; };
 	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = nullptr; return -1; };
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
 
 	// iPausableService
 	RESULT pause();

--- a/lib/service/servicewebts.h
+++ b/lib/service/servicewebts.h
@@ -103,6 +103,7 @@ public:
 	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; };
 	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = nullptr; return -1; };
 	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = nullptr; return -1; };
+	RESULT tap(ePtr<iTapService> &ptr) { ptr = nullptr; return -1; };
 
 	// iPausableService
 	RESULT pause();


### PR DESCRIPTION
* encoder: Initial go at "Broadcom" type transcoding.

It's far from perfect still:
- file transcoding does not yet work really (it stops after a few
  seconds). This has probably to do with an interaction between the
  Broadcom encoder and the async I/O Enigma uses for data transfer
  operations also possible in combination with a possible lack of
  back pressure from the encoder to the file.
- a eDVBTSRecorder object is used for pushing the data from the
  demuxer to the encoder. The Broadcom encoder needs this to be
  done in userspace. This object type may or may not be the best
  choice for this, I am not sure.

This needs a few modifications to obvious and less obvious source code:
- changes to encoder to incorporate an additional data pusher
  from demux to encoder
- changes to encoder to store more context per encoding thread
- changes to encoder to fetch the relevant pids, for which we must
  wait for the PMT to be received and parsed (event).
- changes to servicedvb to implement a "TS tap", a thread that copies
  data from the demux to a random fd (encoder in this case). I am not
  sure if this is the "best" approach, Enigma might already have another
  mechanism for this, but I didn't find it.
- changes to demux to make the buffer size for the eDVBTSRecoders fully
  customisable, because the Broadcom encoder requires data to be fetched
  in chunks of exactly 256*188 bytes. For this I added an explicit
  buffersize parameter to various locations, which normally is '-1',
  the default value as usual.

Todo:
- check whether all /proc nodes also match for the Broadcom encoder,
  probably not and fix that.
- fix file transcoding. It will probably going to boil down to remove
  the call to the eDVBRecordStreamThread in streamerver.cpp and replace
  it with a simple "read buffer from fd_1, write buffer to fd_2" thread,
  at least for Broadcom transcoding. That will probably fix the issue.

There will probably be issues with the OWIF (in it's role as user
interface to transcoding, not a fundamental one) and probably user
apps on smartphones, which do not always understand transcoding on
tcp poort 8002.

I am open to suggestions.

* encoder: clean some debug/warning statements.

Turn some eDebugs into eWarnings (severe).
Turn some eWarnings into eDebugs (just info).
Add some and remove some eDebugs and eWarnings.

Netto effect should be that enigma2 started with
ENIGMA_DEBUG_LVL=3 should not output anything
other than errors.

(cherry picked from commit f339fbb6be41bdfd6f8a79ffda88b2ba6767001f)

* encoder: cosmetic: rename encoder_t to EncoderContext.

Following C++ naming best practice.

(cherry picked from commit 0c4b4e68b20570fd0cf66884705349dadcc35fb5)

* encoder: cosmetic: rename some fields in EncoderContext.

(cherry picked from commit 85535ad76069496aacc87191bae87f1b5557ab15)

* encoder: adjust added poll call in filepush.

- don't add events that are ignored anyway (as event, not as revent).
- decrease timeout from 1 second to 100 msec because it's not only using
  for transcoding, other purposes might suffer from such a long timeout.

(cherry picked from commit cf31ba1a880c4b46558a84783f03629825a281e1)

* encoder: remove useless "const" specifier on non-reference parameters.

(cherry picked from commit 61bbab9005e4641050eb99eac880d7bfcede42ca)

* encoder: use "recorder" instead of "streamer" for tap service.

We don't want to loose packets (and loose sync) just because the
encoder is a bit slow to start.

(cherry picked from commit d22f73e7e68b7622b06c5e8d930255c3c4456a06)

* encoder: don't stop/cleanup tap service if it isn't started.

This fixes a segfault in certain circumstances.

(cherry picked from commit 2f98a9cb6ff8c47fbb06b4f024ff8bd75c15a9d0)

* filepusher: add synchronous write mode.

The usual asynchronous write mode of the class makes the broadcom
encoder get into a weird state. With normal, synchronous writes
no problems.

(cherry picked from commit b79c3838ab51f2edd78ee0969dacbb665957bfc7)

* encoder: fix file transcoding.

Get the data from the file directly instead of from the demux. Retrieving
the data from the demux requires strict timing and buffering, while getting
it from the file itself imposes no such requirements. So extensive buffering
is not required.

Also use the added synchronous mode of the filepusher, because the
Broadcom encoder can't handle asynchronous write requests.

(cherry picked from commit 73c6a65fb2ca9a0c61e34e9a015b0bd9b917771c)

* encoder: cosmetic: fix typo in comment.

(cherry picked from commit 74cf9e70f8383a650099b6fe30bf9b22b6c5351b)

* encoder: complete the broadcom encoder interface.

You won't win much as most hooks are not implemented.

- audio_codec/video_codec won't work if you choose anything other than default
- framerate, aspect ratio and interlaced are ignored
- width and height are ignore too, you only get to choose between 480p,
  576p and 720p. These are determined from the supplied height value.

So only bitrate and width/height do something (and latter even limited).

(cherry picked from commit 4ad8f1c0b1342cae6c53ded0f1b4d8d00784603b)

* [servicemp3] add missing dummy pure virtual method "tap"

Co-authored-by: Erik Slagter <erik@openpli.org>