### PR TITLE
[keymap] EPGSelectActions flags

### DIFF
--- a/data/keymap.xml
+++ b/data/keymap.xml
@@ -825,7 +825,7 @@
 	</map>
 
 	<map context="EPGSelectActions">
-		<key id="KEY_GREEN" mapto="timerAdd" flags="b" />
+		<key id="KEY_GREEN" mapto="timerAdd" flags="m" />
 		<key id="KEY_CHANNELUP" mapto="nextService" flags="m" />
 		<key id="KEY_CHANNELDOWN" mapto="prevService" flags="m" />
 		<key id="KEY_NEXT" mapto="nextBouquet" flags="m" />
@@ -846,7 +846,7 @@
 		<key id="KEY_FAVORITES" mapto="tvlong" flags="l" />
 		<key id="KEY_PROGRAM" mapto="timer" flags="b" />
 		<key id="KEY_PROGRAM" mapto="timerlong" flags="l" />
-		<key id="KEY_BACK" mapto="back" flags="b" />
+		<key id="KEY_BACK" mapto="back" flags="m" />
 	</map>
 
 	<map context="EventViewActions">


### PR DESCRIPTION
"b" flag is used when a key has a long event, otherwise "m"